### PR TITLE
Rework postgrest ACLs and Explicitly bind-mount in PEM files

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   haproxy:
-    image: haproxy:latest
+    image: haproxy:lts
     container_name: haproxy
     ports:
       - "80:80"

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -1,7 +1,9 @@
 global
     maxconn 4096
 
-    # intermediate configuration
+    # generated 2025-05-14, Mozilla Guideline v5.7, HAProxy 3.0, OpenSSL 3.4.0, intermediate config
+    # https://ssl-config.mozilla.org/#server=haproxy&version=3.0&config=intermediate&openssl=3.4.0&guideline=5.7
+
     ssl-default-bind-curves X25519:prime256v1:secp384r1
     ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -47,8 +47,7 @@ frontend http_front
     use_backend server_not_found
 
 frontend https_front
-    bind *:443 ssl crt /usr/local/etc/haproxy/ssl alpn h2,http/1.1
-
+    bind *:443 ssl crt /usr/local/etc/haproxy/ssl/equitytool.austinmobility.io.pem alpn h2,http/1.1
     capture request header host len 31
     log-format "%ci:%cp [%t] %ft %b/%s %TR/%Tw/%Tc/%Tr/%Tt %ST %B %tsc %{+Q}r captured_host=%[capture.req.hdr(0)]"
 

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -32,23 +32,17 @@ frontend http_front
     acl host_equitytool req.hdr(host) -i -m beg equitytool.austinmobility.io
     redirect scheme https code 301 if host_equitytool
 
-    # PostgREST Path ACLs
-    acl path_knack_services path_beg /knack-services
-    acl path_legacy_scripts path_beg /legacy-scripts
-    acl path_ctr_data_lake path_beg /ctr-data-lake
-    acl path_parking path_beg /parking
-    acl path_road_conditions path_beg /road-conditions
-    acl path_bond_reporting path_beg /bond-reporting
+    # Only go to postgrest if the path is valid AND:
+    #   - either source is 10.0.0.0/8
+    #   - or source is 162.89.100.0/24 and host header is present
 
-    # Host and source ACLs
+    acl path_postgrest path_beg /knack-services /legacy-scripts /ctr-data-lake /parking /road-conditions /bond-reporting
     acl host_postgrest hdr(host) -i atd-postgrest.austinmobility.io
     acl src_postgrest_internal src 10.0.0.0/8
     acl src_postgrest_coa_network src 162.89.100.0/24
 
-    # Only go to postgrest if the path is valid AND:
-    #   - either source is 10.0.0.0/8
-    #   - or source is 162.89.100.0/24 and host header is present
-    use_backend postgrest if (path_knack_services or path_legacy_scripts or path_ctr_data_lake or path_parking or path_road_conditions or path_bond_reporting) and ( src_postgrest_internal or ( src_postgrest_coa_network and host_postgrest ) )
+    use_backend postgrest if path_postgrest src_postgrest_internal
+    use_backend postgrest if path_postgrest src_postgrest_coa_network host_postgrest
 
     use_backend server_not_found
 

--- a/ssl/README.md
+++ b/ssl/README.md
@@ -1,7 +1,3 @@
 # SSL certificates and keys
 
 Place `pem` files in here for SSL termination. They should be named as <fully qualified domain name>.pem. For example, if your domain is `example.com`, the file should be named `example.com.pem`. The file should contain both the certificate and the private key in PEM format.
-
-# Last Step
-
-This file serves as a placeholder to show you where to put your SSL certificates and keys. The file should be removed before running the container.


### PR DESCRIPTION
This is an update that fell out of the April updates for the RDS bastion. On restarting HAProxy, I discovered that I had slipped in a syntax error in the postgrest ACLs and this fixes it. Please review the code, this is already in production as we do not have a development environment for this.

I am also switching us to explicit bind-mounts for PEM files.

Edit: I'm also going to move this from my personal development area in my home directory into /srv when I merge this, so that'll be the last step bringing this repo online and into our operation.