### PR TITLE
Remove route matching test when handling postgREST requests

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -53,11 +53,10 @@ frontend https_front
     # 2) using the postgrest hostname
     # 3) be coming in from the COA network
 
-    acl path_postgrest path_beg /knack-services /legacy-scripts /parking /road-conditions /bond-reporting
     acl host_postgrest hdr(host) -i atd-postgrest.austinmobility.io
     acl src_postgrest_coa_network src 162.89.100.0/24
 
-    use_backend postgrest if path_postgrest host_postgrest src_postgrest_coa_network
+    use_backend postgrest if host_postgrest src_postgrest_coa_network
 
 
     # Use the equitymap backend if the equitymap ACL matches


### PR DESCRIPTION
This is in service of https://github.com/cityofaustin/atd-data-tech/issues/23700. I've deployed this change on production, where it's currently running