### PR TITLE
Define 10 minute timeout on connections related to accessing the read replica

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -18,9 +18,9 @@ global
 defaults
     log     global
     option  dontlognull
-    timeout connect 5000ms
-    timeout client  50000ms
-    timeout server  50000ms
+    timeout connect 5s
+    timeout client  50s
+    timeout server  50s
 
 frontend http_front
     bind *:80
@@ -73,7 +73,7 @@ frontend https_front
 
 frontend postgresql_front
     mode tcp
-    timeout client 600000
+    timeout client 10m
     bind *:5432
     default_backend postgresql_back
 
@@ -94,7 +94,7 @@ backend citybase_uat
     server citybase_uat_server host.docker.internal:5000 check
 
 backend postgresql_back
-  timeout server 600000
+  timeout server 10m
   server postgresql_server ${DATABASE_SERVER}:5432
 
 backend server_not_found

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -73,6 +73,7 @@ frontend https_front
 
 frontend postgresql_front
     mode tcp
+    timeout client 600000
     bind *:5432
     default_backend postgresql_back
 
@@ -93,6 +94,7 @@ backend citybase_uat
     server citybase_uat_server host.docker.internal:5000 check
 
 backend postgresql_back
+  timeout server 600000
   server postgresql_server ${DATABASE_SERVER}:5432
 
 backend server_not_found


### PR DESCRIPTION
# What?

This PR extends the timeout of 50 seconds to 10 minutes for TCP/IP connections coming into the `haproxy` instance that are handled by the read replica front-end configuration as well as connections from `haproxy` to the read replica instance.

This PR also switches from defining time durations in milliseconds to using more human readable units. ([docs](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#2.5))

# Why?

This PR is part of the solution around https://github.com/cityofaustin/atd-data-tech/issues/24005 and needed for the deployment of [this Moped PR](https://github.com/cityofaustin/atd-moped/pull/1652).

# Testing

I'd venture that this is good enough with an eyeball test by looking at the very small diff.

If you want to see it spin up however, you'll need to grab the PEM files off the bastion and put them in your SSL folder to get `haproxy` to start. But once it starts -- that's the whole test, it's good to go.

## Questions to consider

* Are the two timeouts set in the right sections?
* Are they set for 10 minutes?