### PR TITLE
Update citybase staging and UAT certbot cron entries to `cd` to the correct working directory

### DIFF
--- a/toolbox/certbot/certbot_renewals.cron
+++ b/toolbox/certbot/certbot_renewals.cron
@@ -6,3 +6,4 @@
 2 7,19 * * 1-5 root cd /srv/dts-services-haproxy/toolbox/certbot/; ./renew_ssl_tls_certbot_certificate.sh -d equitytool.austinmobility.io -t /srv/dts-services-haproxy/ssl -c haproxy >> /var/log/certbot-equitytool.log 2>&1
 4 7,19 * * 1-5 root cd /srv/dts-services-haproxy/toolbox/certbot/; ./renew_ssl_tls_certbot_certificate.sh -d citybase-staging.austinmobility.io -t /srv/dts-services-haproxy/ssl -c haproxy >> /var/log/certbot-citybase-staging.log 2>&1
 6 7,19 * * 1-5 root cd /srv/dts-services-haproxy/toolbox/certbot/; ./renew_ssl_tls_certbot_certificate.sh -d citybase-uat.austinmobility.io -t /srv/dts-services-haproxy/ssl -c haproxy >> /var/log/certbot-citybase-uat.log 2>&1
+8 7,19 * * 1-5 root cd /srv/dts-services-haproxy/toolbox/certbot/; ./renew_ssl_tls_certbot_certificate.sh -d citybase.austinmobility.io -t /srv/dts-services-haproxy/ssl -c haproxy >> /var/log/certbot-citybase-production.log 2>&1

--- a/toolbox/certbot/certbot_renewals.cron
+++ b/toolbox/certbot/certbot_renewals.cron
@@ -4,5 +4,5 @@
 
 0 7,19 * * 1-5 root cd /srv/dts-services-haproxy/toolbox/certbot/; ./renew_ssl_tls_certbot_certificate.sh -d atd-postgrest.austinmobility.io -t /srv/dts-services-haproxy/ssl -c haproxy >> /var/log/certbot-atd-postgrest.log 2>&1
 2 7,19 * * 1-5 root cd /srv/dts-services-haproxy/toolbox/certbot/; ./renew_ssl_tls_certbot_certificate.sh -d equitytool.austinmobility.io -t /srv/dts-services-haproxy/ssl -c haproxy >> /var/log/certbot-equitytool.log 2>&1
-4 7,19 * * 1-5 root /srv/dts-services-haproxy/toolbox/certbot/renew_ssl_tls_certbot_certificate.sh -d citybase-staging.austinmobility.io -t /srv/dts-services-haproxy/ssl -c haproxy >> /var/log/certbot-citybase-staging.log 2>&1
-6 7,19 * * 1-5 root /srv/dts-services-haproxy/toolbox/certbot/renew_ssl_tls_certbot_certificate.sh -d citybase-uat.austinmobility.io -t /srv/dts-services-haproxy/ssl -c haproxy >> /var/log/certbot-citybase-uat.log 2>&1
+4 7,19 * * 1-5 root cd /srv/dts-services-haproxy/toolbox/certbot/; ./renew_ssl_tls_certbot_certificate.sh -d citybase-staging.austinmobility.io -t /srv/dts-services-haproxy/ssl -c haproxy >> /var/log/certbot-citybase-staging.log 2>&1
+6 7,19 * * 1-5 root cd /srv/dts-services-haproxy/toolbox/certbot/; ./renew_ssl_tls_certbot_certificate.sh -d citybase-uat.austinmobility.io -t /srv/dts-services-haproxy/ssl -c haproxy >> /var/log/certbot-citybase-uat.log 2>&1


### PR DESCRIPTION
# Why?

No issue on this one, this tiny PR is the result of a quick pairing with @chiaberry this morning to diagnose an expired cert. We identified how we had used absolute paths on these two cron entries and that we needed to first change to the right directory and invoke the script from there. 

# Anything else?

Funny you ask! Yes, we are also going to add a new cron entry for the production Citybase service now that it's running on the bastion. You can see this new entry at the bottom of the file.

# Testing

Click the links and observe no TLS/SSL errors: https://citybase-uat.austinmobility.io/ & https://citybase-staging.austinmobility.io/. A `503` is fine on UAT if you see one, what we're looking for is no TLS/SSL errors.